### PR TITLE
Add lower case filenames option

### DIFF
--- a/code-generator.js
+++ b/code-generator.js
@@ -242,7 +242,7 @@ class PythonCodeGenerator {
     // Import
     if (_inherits.length > 0) {
       _inherits.forEach(function (e) {
-        var _path = e.getPath(self.baseModel).map(function (item) { return item.name }).join('.')
+        var _path = e.getPath(self.baseModel).map(function (item) { return ((options.lowerCase) ? item.name.toLowerCase() : item.name) }).join('.')
         codeWriter.writeLine('from ' + _path + ' import ' + e.name)
       })
       codeWriter.writeLine()
@@ -314,7 +314,7 @@ class PythonCodeGenerator {
 
     // Class
     } else if (elem instanceof type.UMLClass || elem instanceof type.UMLInterface) {
-      fullPath = basePath + '/' + elem.name + '.py'
+      fullPath = basePath + '/' + ((options.lowerCase) ? elem.name.toLowerCase() : elem.name) + '.py'
       codeWriter = new codegen.CodeWriter(this.getIndentString(options))
       codeWriter.writeLine(options.installPath)
       codeWriter.writeLine('# -*- coding: utf-8 -*-')
@@ -324,7 +324,7 @@ class PythonCodeGenerator {
 
     // Enum
     } else if (elem instanceof type.UMLEnumeration) {
-      fullPath = basePath + '/' + elem.name + '.py'
+      fullPath = basePath + '/' + ((options.lowerCase) ? elem.name.toLowerCase() : elem.name) + '.py'
       codeWriter = new codegen.CodeWriter(this.getIndentString(options))
       codeWriter.writeLine(options.installPath)
       codeWriter.writeLine('# -*- coding: utf-8 -*-')

--- a/main.js
+++ b/main.js
@@ -28,7 +28,8 @@ function getGenOptions () {
     installPath: app.preferences.get('python.gen.installPath'),
     useTab: app.preferences.get('python.gen.useTab'),
     indentSpaces: app.preferences.get('python.gen.indentSpaces'),
-    docString: app.preferences.get('python.gen.docString')
+    docString: app.preferences.get('python.gen.docString'),
+    lowerCase: app.preferences.get('python.gen.lowerCase')
   }
 }
 

--- a/preferences/preference.json
+++ b/preferences/preference.json
@@ -29,6 +29,12 @@
       "description": "Generate docstrings.",
       "type": "check",
       "default": true
-    }        
+    },
+    "python.gen.lowerCase": {
+      "text": "Lower Case Filenames",
+      "description": "Make filenames lower case, according to PEP8 recommendation.",
+      "type": "check",
+      "default": false
+    }
   }
 }


### PR DESCRIPTION
I'd like to add lower case filenames option. It is PEP8 compliant.
More about naming convention for modules and packages here:
https://www.python.org/dev/peps/pep-0008/#package-and-module-names

For now I'm setting it to false by default (so there is no surprise for those using standard approach).